### PR TITLE
Add components query parameter

### DIFF
--- a/lib/src/searchMapPlaceWidget.dart
+++ b/lib/src/searchMapPlaceWidget.dart
@@ -17,6 +17,7 @@ class SearchMapPlaceWidget extends StatefulWidget {
     this.placeType,
     this.darkMode = false,
     this.key,
+    this.countries,
   })  : assert((location == null && radius == null) || (location != null && radius != null)),
         super(key: key);
 
@@ -71,6 +72,9 @@ class SearchMapPlaceWidget extends StatefulWidget {
 
   /// Enables Dark Mode when set to `true`. Default value is `false`.
   final bool darkMode;
+
+  /// List of countries to restrict to.
+  final List<String> countries;
 
   @override
   _SearchMapPlaceWidgetState createState() => _SearchMapPlaceWidgetState();
@@ -297,13 +301,20 @@ class _SearchMapPlaceWidgetState extends State<SearchMapPlaceWidget> with Ticker
     String url =
         "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=$input&key=${widget.apiKey}&language=${widget.language}";
     if (widget.location != null && widget.radius != null) {
-      url += "&location=${widget.location.latitude},${widget.location.longitude}&radius=${widget.radius}";
+      url +=
+          "&location=${widget.location.latitude},${widget.location.longitude}&radius=${widget.radius}";
       if (widget.strictBounds) {
         url += "&strictbounds";
       }
       if (widget.placeType != null) {
         url += "&types=${widget.placeType.apiString}";
       }
+    }
+
+    if (widget.countries != null) {
+      String _components =
+          widget.countries.map((String _country) => 'country:' + _country).join('|');
+      url += "&components=" + _components;
     }
 
     final response = await http.get(url);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: search_map_place
 description: A Search Widget that allows users to search for a place while getting autocompletion feedback.
-version: 0.3.0
+version: 0.3.1
 author: Lucas Bernardi <lucasbernardi.23@gmail.com>
 homepage: https://github.com/Bernardi23/search_map_place
 


### PR DESCRIPTION
This allows to provide countries to narrow query results.
Countries must be passed as two-alpha characters string.

https://developers.google.com/places/web-service/autocomplete